### PR TITLE
fix: critical bugs in JET, MSSQL converters and SparxImporter

### DIFF
--- a/AAroN-Core/src/main/java/aaron/sparx/SparxJETConverter.java
+++ b/AAroN-Core/src/main/java/aaron/sparx/SparxJETConverter.java
@@ -54,8 +54,6 @@ public class SparxJETConverter extends AbstractSparxConverter {
 
         iterateJETTable(sha1, now, this::processSystem, db.getTable(EASystem.TABLE_NAME));
 
-        iterateJETTable(sha1, now, this::processSystem, db.getTable(EASystem.TABLE_NAME));
-
         iterateJETTable(sha1, now, this::processPackages, db.getTable(EAPackage.TABLE_NAME));
 
         iterateJETTable(sha1, now, this::processDiagrams, db.getTable(EADiagram.TABLE_NAME));

--- a/AAroN-Core/src/main/java/aaron/sparx/SparxMSSQLConverter.java
+++ b/AAroN-Core/src/main/java/aaron/sparx/SparxMSSQLConverter.java
@@ -110,6 +110,6 @@ public class SparxMSSQLConverter extends AbstractSparxConverter {
                 throw new RuntimeException(e);
             }
         }
-        return null;
+        throw new RuntimeException("Could not establish connection to MSSQL database at " + host + ":" + port);
     }
 }

--- a/AAroN-Plugin/src/main/java/aaron/plugin/sparx/SparxImporter.java
+++ b/AAroN-Plugin/src/main/java/aaron/plugin/sparx/SparxImporter.java
@@ -78,6 +78,10 @@ public class SparxImporter {
                 model = converter.convert();
             } catch (IOException e) {
                 log.error("IO Error", e);
+                throw new RuntimeException("EAP conversion failed: " + e.getMessage(), e);
+            }
+            if (model == null) {
+                throw new RuntimeException("EAP conversion returned null model");
             }
             ModelProcessor modelProcessor = new ModelProcessor(db, reporter);
             modelProcessor.process(model);
@@ -115,6 +119,10 @@ public class SparxImporter {
                 model = converter.convert();
             } catch (IOException e) {
                 log.error("IO Error", e);
+                throw new RuntimeException("MySQL conversion failed: " + e.getMessage(), e);
+            }
+            if (model == null) {
+                throw new RuntimeException("MySQL conversion returned null model");
             }
             ModelProcessor modelProcessor = new ModelProcessor(db, reporter);
             modelProcessor.process(model);
@@ -160,6 +168,10 @@ public class SparxImporter {
                 model = converter.convert();
             } catch (IOException e) {
                 log.error("IO Error", e);
+                throw new RuntimeException("MSSQL conversion failed: " + e.getMessage(), e);
+            }
+            if (model == null) {
+                throw new RuntimeException("MSSQL conversion returned null model");
             }
             ModelProcessor modelProcessor = new ModelProcessor(db, reporter);
             modelProcessor.process(model);


### PR DESCRIPTION
## 🔧 Bug Fixes

This PR addresses 3 critical bugs discovered during a code review of the AAroN codebase.

### Fix 1: Duplicate `processSystem` in `SparxJETConverter` 
**File:** `AAroN-Core/…/SparxJETConverter.java`  
**Bug:** `usyst_system` table processed twice (lines 55 + 57), creating duplicate System nodes in Neo4j.  
**Fix:** Removed duplicate line 57.

### Fix 2: `SparxMSSQLConverter` returns null on connection failure
**File:** `AAroN-Core/…/SparxMSSQLConverter.java`  
**Bug:** When all 3 connection attempts fail, method returns `null`, causing NPE in callers.  
**Fix:** Throw `RuntimeException` with meaningful message instead of `return null`.

### Fix 3: `SparxImporter` NPE when converter throws IOException
**File:** `AAroN-Plugin/…/SparxImporter.java`  
**Bug:** All three import procedures (`importEAP`, `importMySQL`, `importMSSQL`) catch `IOException` but leave `model = null`, causing NPE in `ModelProcessor.process()`.  
**Fix:** Re-throw as `RuntimeException` + add null check after conversion.

---

**Related Issues:** Closes #19, Closes #20, Closes #21

**Tested:** Not yet — these are targeted fixes for clear logic bugs. A test suite would be valuable for the processor pipeline (see #21 for discussion).